### PR TITLE
Updated multimeter to display negative voltages

### DIFF
--- a/src/circuit/multimeter-base.js
+++ b/src/circuit/multimeter-base.js
@@ -16,8 +16,9 @@ MultimeterBase.prototype = {
 
         this.mode = this.modes.ohmmeter;
 
-        this.absoluteValue = 0;   //current meter value
-
+        this.absoluteValue = 0;   // current absolute meter value
+        this.value = 0;           // current real meter value
+        
         this.displayText = '       ';
 
         this.redProbeConnection = null;
@@ -55,6 +56,14 @@ MultimeterBase.prototype = {
 
     updateDisplay : function () {
         var text = '',
+            self = this,
+            toSignedDisplayString = function (s, dec) {
+              return self.toDisplayString((self.value < 0 ? '-' : '') + s, dec);
+            },
+            prependHV = function (s) {
+              // if there is a leading negative place it in the second position so that both HV and the negative sign will display
+              return s.substr(0, 1) === '-' ? 'h-' + text.substring(2) : 'h' + text.substring(1)
+            },
             vm, imc, im;
 
         if (!this.powerOn) {
@@ -66,7 +75,7 @@ MultimeterBase.prototype = {
             if (this.dialPosition === 'dcv_20') {
                 if (this.absoluteValue < 19.995) {
                     text = (Math.round(this.absoluteValue * 100) * 0.01).toString();
-                    text = this.toDisplayString(text, 2);
+                    text = toSignedDisplayString(text, 2);
                 }
                 else {
                     text = ' 1 .   ';
@@ -76,7 +85,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'dcv_200') {
                 if (this.absoluteValue < 199.95) {
                     text = (Math.round(this.absoluteValue * 10) * 0.1).toString();
-                    text = this.toDisplayString(text, 1);
+                    text = toSignedDisplayString(text, 1);
                 }
                 else {
                     text = ' 1 .   ';
@@ -86,8 +95,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'dcv_1000') {
                  if (this.absoluteValue < 999.95) {
                     text = Math.round(this.absoluteValue).toString();
-                    text = this.toDisplayString(text, 0);
-                    text = "h" + text.substring(1);
+                    text = prependHV(toSignedDisplayString(text, 0));
                 }
                 else {
                     text = 'h1 .   ';
@@ -98,7 +106,7 @@ MultimeterBase.prototype = {
                 vm = this.absoluteValue * 1000;
                 if (vm < 1999.5) {
                     text = Math.round(vm).toString();
-                    text = this.toDisplayString(text, 0);
+                    text = toSignedDisplayString(text, 0);
                 }
                 else {
                     text = ' 1 .   ';
@@ -109,7 +117,7 @@ MultimeterBase.prototype = {
                 vm = this.absoluteValue * 1000;
                 if (vm < 195){
                   text = (Math.round(vm * 100) * 0.01).toString();
-                  text = this.toDisplayString(text, 1);
+                  text = toSignedDisplayString(text, 1);
                 }
                 else {
                     text = ' 1 .   ';
@@ -119,7 +127,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'acv_200') {
                 if (this.absoluteValue < 199.95) {
                     text = (Math.round(this.absoluteValue * 10) * 0.1).toString();
-                    text = this.toDisplayString(text, 1);
+                    text = toSignedDisplayString(text, 1);
                 }
                 else {
                     text = ' 1 .   ';
@@ -129,8 +137,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'acv_750') {
                 if (this.absoluteValue < 699.5) {
                     text = (Math.round(this.absoluteValue)).toString();
-                    text = this.toDisplayString(text, 0);
-                    text = "h"+text.substring(1);
+                    text = prependHV(toSignedDisplayString(text, 0));
                 }
                 else {
                     text = 'h1 .   ';
@@ -140,7 +147,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'r_200') {
                 if (this.absoluteValue < 199.95) {
                     text = (Math.round(this.absoluteValue * 10) * 0.1).toString();
-                    text = this.toDisplayString(text, 1);
+                    text = toSignedDisplayString(text, 1);
                 }
                 else {
                     text = ' 1   . ';
@@ -149,7 +156,7 @@ MultimeterBase.prototype = {
             } else if (this.dialPosition === 'r_2000') {
                 if (this.absoluteValue < 1999.5) {
                     text = Math.round(this.absoluteValue).toString();
-                    text = this.toDisplayString(text, 0);
+                    text = toSignedDisplayString(text, 0);
                 }
                 else {
                     text = ' 1     ';
@@ -159,7 +166,7 @@ MultimeterBase.prototype = {
             else if (this.dialPosition === 'r_20k') {
                 if (this.absoluteValue < 19995) {
                     text = (Math.round(this.absoluteValue * 0.1) * 0.01).toString();
-                    text = this.toDisplayString(text, 2);
+                    text = toSignedDisplayString(text, 2);
                 }
                 else {
                     text = ' 1 .   ';
@@ -169,7 +176,7 @@ MultimeterBase.prototype = {
             else if (this.dialPosition === 'r_200k') {
                 if (this.absoluteValue < 199950) {
                     text = (Math.round(this.absoluteValue * 0.01) * 0.1).toString();
-                    text = this.toDisplayString(text, 1);
+                    text = toSignedDisplayString(text, 1);
                 }
                 else {
                     text = ' 1   . ';
@@ -179,7 +186,7 @@ MultimeterBase.prototype = {
             else if (this.dialPosition === 'r_2000k') {
                 if (this.absoluteValue < 1999500) {
                     text = Math.round(this.absoluteValue * 0.001).toString();
-                    text = this.toDisplayString(text, 0);
+                    text = toSignedDisplayString(text, 0);
                 }
                 else {
                     text = ' 1     ';
@@ -190,7 +197,7 @@ MultimeterBase.prototype = {
               imc = this.absoluteValue * 1000000;
               if (imc < 195){
                 text = (Math.round(imc * 100) * 0.01).toString();
-                text = this.toDisplayString(text, 1);
+                text = toSignedDisplayString(text, 1);
               }
               else {
                   text = ' 1     ';
@@ -201,7 +208,7 @@ MultimeterBase.prototype = {
               imc = this.absoluteValue * 1000000;
               if (imc < 1950){
                 text = (Math.round(imc * 10) * 0.1).toString();
-                text = this.toDisplayString(text, 0);
+                text = toSignedDisplayString(text, 0);
               }
               else {
                   text = ' 1     ';
@@ -212,7 +219,7 @@ MultimeterBase.prototype = {
               im = this.absoluteValue * 1000;
               if (im < 19.5){
                 text = (Math.round(im * 100) * 0.01).toString();
-                text = this.toDisplayString(text, 2);
+                text = toSignedDisplayString(text, 2);
               }
               else {
                   text = ' 1     ';
@@ -223,7 +230,7 @@ MultimeterBase.prototype = {
               im = this.absoluteValue * 1000;
               if (im < 195){
                 text = (Math.round(im * 10) * 0.1).toString();
-                text = this.toDisplayString(text, 1);
+                text = toSignedDisplayString(text, 1);
               }
               else {
                   text = ' 1     ';

--- a/src/circuit/multimeter.js
+++ b/src/circuit/multimeter.js
@@ -75,6 +75,7 @@ extend(Multimeter, MultimeterBase, {
 
         // exit quickly if ciso was not able to solve circuit
         if (!v1 || !v2) {
+          this.value = 0;
           this.absoluteValue = 0;
           this.updateDisplay();
           return;
@@ -107,6 +108,10 @@ extend(Multimeter, MultimeterBase, {
         }
         result = Math.round(result*Math.pow(10,8))/Math.pow(10,8);
 
+        // track both the value and the absolute value.  the absolute value lets us
+        // make simpler one-sided comparisons to zero and the value lets us display
+        // the negative sign
+        this.value = result;
         this.absoluteValue = Math.abs(result);
 
         if (measurement === "current" && this.absoluteValue > 0.44){

--- a/src/circuit/multimeter.js
+++ b/src/circuit/multimeter.js
@@ -54,7 +54,7 @@ extend(Multimeter, MultimeterBase, {
   // this is called after update() is called and ciso returns
   updateWithData: function (ciso) {
     var measurement = this.currentMeasurement,
-        source, b, p1, p2, v1, v2, current, drop,
+        source, b, p1, p2, v1, v2, current,
         result;
 
     if (ciso) {
@@ -81,12 +81,16 @@ extend(Multimeter, MultimeterBase, {
           return;
         }
 
-        drop = v1.subtract(v2).magnitude;
-
-        if (measurement === "current") {
-          result = drop / 1e-6;
-        } else {
-          result = drop;
+        switch (measurement) {
+          case "voltage":
+            result = v1.real - v2.real;
+            break;
+          case "ac_voltage":
+            result = v1.subtract(v2).magnitude;
+            break;
+          case "current":
+            result = v1.subtract(v2).magnitude / 1e-6
+            break;
         }
       }
 


### PR DESCRIPTION
Added tracking of actual value along with existing absolute value in
the multimeter component.  The absolute value is still used as is in
the code with the actual value providing the sign before the display
is updated.

A small change was also needed to allow both the HV and negative sign
to display at the same time.  If both need to display the second blank
space is used for the sign, eg 'h 3 0 0' becomes 'h-3 0 0'.
