### PR TITLE
Added probe dropped event and fixed circuit option

### DIFF
--- a/src/models/log.js
+++ b/src/models/log.js
@@ -11,6 +11,7 @@ LogEvent.DMM_MEASUREMENT = "DMM measurement";
 LogEvent.CHANGED_CIRCUIT = "Changed circuit";
 LogEvent.ATTACHED_PROBE = "Attached probe";
 LogEvent.DETACHED_PROBE = "Detached probe";
+LogEvent.DROPPED_PROBE = "Dropped probe";
 LogEvent.MOVED_DMM_DIAL = "Moved DMM dial";
 LogEvent.OSCOPE_MEASUREMENT = "OScope measurement";
 LogEvent.OSCOPE_V1_SCALE_CHANGED = "OScope V1 scale changed";

--- a/src/views/breadboard-svg-view.js
+++ b/src/views/breadboard-svg-view.js
@@ -1757,7 +1757,7 @@ window["breadboardSVGView"] = {
           };
           lead_new = findLeadUnderProbe(board, point);
           if (lead_init) {
-            board.sendEventToModel("probeRemoved", [active.name, active.color]);
+            board.sendEventToModel("probeRemoved", [active.name, active.color, lead_init.hole]);
             lead_init = null;
           }
           if (lead_new) {
@@ -1784,8 +1784,11 @@ window["breadboardSVGView"] = {
           active.dy = y;
           if (lead_new) {
             active.setState(lead_new);
-          } else if (active.lead) {
-            active.lead = null;
+          } else {
+            board.sendEventToModel("probeDropped", [active.name, active.color, {x: active.x, y: active.y, dx: active.dx, dy: active.dy}]);
+            if (active.lead) {
+              active.lead = null;
+            }
           }
           active.image.update();
           active = null;
@@ -1871,6 +1874,14 @@ window["breadboardSVGView"] = {
 
   primitive.probe.prototype.hide = function() {
     this.css('visibility', 'hidden');
+  };
+
+  primitive.probe.prototype.move = function(pos) {
+    this.x = pos.x;
+    this.y = pos.y;
+    this.dx = pos.dx;
+    this.dy = pos.dy;
+    this.view.attr('transform', 'translate(' + this.dx + ',' + this.dy + ')');
   };
 
   primitive.mmbox = function(board, params) {

--- a/src/views/breadboard-svg-view.js
+++ b/src/views/breadboard-svg-view.js
@@ -18,11 +18,11 @@ window["breadboardSVGView"] = {
         "x": 80,
         "y": 80
       }
-    }
+    },
+    "fixedCircuit": false
   },
   "util" : {}
 };
-
 
 // window["breadboardSVGView"].connectionMade = function(component, location) {
 //   console.log('Received: connect, component|' + component + '|' + location);
@@ -152,6 +152,8 @@ window["breadboardSVGView"] = {
   var _mouseup = (touch ) ? 'touchend' : 'mouseup';
   var _mouseover = (touch ) ? 'xxx' : 'mouseover';
   var _mouseout = (touch ) ? 'xxx' : 'mouseout';
+
+  var options = board.options;
 
   // object contains electronic and test equipment
   var equipment = function() {
@@ -1224,6 +1226,10 @@ window["breadboardSVGView"] = {
       y : 0
     }, pts = [p2, p1];
 
+    if (options.fixedCircuit) {
+      return;
+    }
+
     board.holder[0].addEventListener(_mousedown, function(evt) {
       if (!evt.touches || evt.touches.length == 1) {
         component = $(evt._target).data('component') || null;
@@ -1354,6 +1360,10 @@ window["breadboardSVGView"] = {
       x : 0,
       y : 0
     }, deg, hi, ho, hn;
+
+    if (options.fixedCircuit) {
+      return;
+    }
 
     board.holder[0].addEventListener(_mousedown, function(evt) {
       if (!evt.touches || evt.touches.length == 1) {
@@ -1495,14 +1505,16 @@ window["breadboardSVGView"] = {
     action.data('component-lead', this.name);
 
     // bind onclick events
-    action[0].addEventListener(_mouseup, function(l) {
-      var f = false;
-      return function() {
-        if (!l.isDragged) {
-          l[ (f = !f) ? 'disconnect' : 'connect' ]();
-        }
-      };
-    }(this), false);
+    if (!options.fixedCircuit) {
+      action[0].addEventListener(_mouseup, function(l) {
+        var f = false;
+        return function() {
+          if (!l.isDragged) {
+            l[ (f = !f) ? 'disconnect' : 'connect' ]();
+          }
+        };
+      }(this), false);
+    }
 
     this.view = lead;
   };

--- a/src/views/svg_view_comm.js
+++ b/src/views/svg_view_comm.js
@@ -76,11 +76,19 @@ breadboardComm.probeAdded = function(workbenchController, meter, color, location
   });
 };
 
-breadboardComm.probeRemoved = function(workbenchController, meter, color) {
+breadboardComm.probeRemoved = function(workbenchController, meter, color, location) {
   workbenchController.workbench.meter.setProbeLocation("probe_"+color, null);
   logController.addEvent(LogEvent.DETACHED_PROBE, {
     "color": color,
     "location": location
+  });
+};
+
+breadboardComm.probeDropped = function(workbenchController, meter, color, position) {
+  //workbenchController.workbench.meter.setProbeLocation("probe_"+color, null);
+  logController.addEvent(LogEvent.DROPPED_PROBE, {
+    "color": color,
+    "position": position
   });
 };
 


### PR DESCRIPTION
Also fixed logging of detached probe location.  It was not being passed to the probeRemoved function so window.location was being sent to the logger.

The probe dropped event is needed so we can track probe movements in Teaching Teamwork's "View All" component.
