### PR TITLE
Fixed bug that caused two editor tooltips to show when the component was double clicked [#123226121]

### DIFF
--- a/src/views/breadboard-svg-view.js
+++ b/src/views/breadboard-svg-view.js
@@ -534,17 +534,23 @@ window["breadboardSVGView"] = {
         compWidth  = rect.width,
         compHeight = rect.height,
         tipWidth   = $tipPane.width(),
+        divId      = "tooltip_" + uid,
         yOffset,
         left,
         tipHeight,
         $tooltip;
+
+    // don't allow multiple tootips to show for the same component (double click events were adding 2x tooltips)
+    if ($("#" + divId).length > 0) {
+      return;
+    }
 
     if (compWidth > 300) {    // weird bug
       compWidth = 120;
     }
 
     // wrap pane in bubble pane and then empty pane (for mousout)
-    $tooltip = $("<div>").append(
+    $tooltip = $("<div id='" + divId + "'>").append(
       $("<div class='speech-bubble'>").append($tipPane)
     );
 

--- a/src/views/edit-components-view.js
+++ b/src/views/edit-components-view.js
@@ -21,6 +21,7 @@ EditComponentsView.prototype = {
         $propertyEditor = null,
         sliderChange, selectChange, updateValue, options,
         self = this;
+
     // create editor tooltip
     possibleValues = comp.getEditablePropertyValues();
 
@@ -30,6 +31,9 @@ EditComponentsView.prototype = {
 
     selectChange = function (evt) {
       updateValue(evt, this.value);
+
+      // remove focus from the select so that the mouseleave event in the tooltip activates more smoothly
+      $(this).blur();
     }
 
     updateValue = function (evt, val) {


### PR DESCRIPTION
This only manifested when the select option was added to the component editor.  With the slider both tooltips closed when the mouseleave event triggered but the select element sometimes caused a focus change which prevented the hidden tooltip from closing.  This made the UI look like it "reset" the edited field.
