### PR TITLE
Added check for non-zero width and height before drawing image

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "breadboard",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "homepage": "https://github.com/concord-consortium/breadboard",
   "description": "A DC and AC breadboard circuit simulator",
   "authors": [

--- a/src/views/breadboard-svg-view.js
+++ b/src/views/breadboard-svg-view.js
@@ -667,7 +667,9 @@ window.breadboardSVGView = {
     this.cnv.transform(20, 0, 0, 20, 0, 1000);
     this.cnv.scale(this.ozoom, this.ozoom);
     // draw pattern element
-    this.cnv.drawImage(this.ctx.canvas, 0, 0, this.w, this.h);
+    if ((this.w > 0) && (this.h > 0)) {
+      this.cnv.drawImage(this.ctx.canvas, 0, 0, this.w, this.h);
+    }
     // restore context
     this.cnv.restore();
 
@@ -846,7 +848,9 @@ window.breadboardSVGView = {
     this.cnv.scale(this.ozoom, this.ozoom);
 
     // draw template image
-    this.cnv.drawImage(this.ctx.canvas, 0, 0, this.w, this.h);
+    if ((this.w > 0) && (this.h > 0)) {
+      this.cnv.drawImage(this.ctx.canvas, 0, 0, this.w, this.h);
+    }
 
     // debugging
     //this.cnv.canvas.style.border = "1px solid blue";


### PR DESCRIPTION
A zero height probe image was causing Teaching Teamwork to throw an error